### PR TITLE
Added missing authToken line for .npmrc

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
 
     env:
       working-dir: ./
+      TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 @lana:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${TOKEN}
+//npm.pkg.github.com/:_authToken=${GITHUBACCESSTOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-@lana:registry=https://npm.pkg.github.com
+@lana:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 @lana:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUBACCESSTOKEN}
+//npm.pkg.github.com/:_authToken=${TOKEN}


### PR DESCRIPTION
## Description
I've added back a missing line from `.npmrc` for the GitHub auth token.

## Testing
  * **Unit-Testing**: N/A
  * **ESLint**: N/A

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
