### PR TITLE
Fix rollup esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Lana B2C Microapp UI Assets, icons and images for general use.",
 	"repository": {
 		"type": "git",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -3,7 +3,6 @@ import svg from 'rollup-plugin-vue-inline-svg';
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
 import globals from 'rollup-plugin-node-globals';
 import postcss from 'rollup-plugin-postcss';
 import autoprefixer from 'autoprefixer';
@@ -14,7 +13,7 @@ const config = {
   input: 'src/index.js',
   output: {
     file: 'dist/bundle-esm.js',
-    format: 'esm',
+    format: 'es',
     name: 'b2cMappUiAssets',
     sourcemap: false,
   },
@@ -42,7 +41,6 @@ const config = {
       ...babelConfig,
       runtimeHelpers: true,
     }),
-    terser(),
   ],
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ import WarningLineIcon from './icons/warningLine.svg';
 import WaterIcon from './icons/water.svg';
 import './styles/styles.scss';
 
-const libraryIcons = {
+export {
   AddBeneficiaryIcon,
   AddBoldIcon,
   AddIcon,
@@ -422,5 +422,3 @@ const libraryIcons = {
   WarningLineIcon,
   WaterIcon,
 };
-
-export default libraryIcons;


### PR DESCRIPTION
## Description
Fixes our Rollup esm build to stop using default export (also disables minification for the esm build)

## Testing
I tested locally importing the built esm library from the ui-assets library project

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
