### PR TITLE
Fixed ColorLockIcon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.7.10",
+	"version": "4.7.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.7.10",
+	"version": "4.7.11",
 	"description": "Lana B2C Microapp UI Assets, icons and images for general use.",
 	"repository": {
 		"type": "git",

--- a/src/components/ColorLockIcon/ColorLockIcon.vue
+++ b/src/components/ColorLockIcon/ColorLockIcon.vue
@@ -4,141 +4,75 @@
        data-name="Capa 1"
        xmlns="http://www.w3.org/2000/svg"
        xmlns:xlink="http://www.w3.org/1999/xlink"
-       viewBox="0 0 40.797 44"
+       viewBox="0 0 30 43"
   >
     <defs>
-      <clipPath id="clip-path" transform="translate(0.4 2)">
+      <clipPath id="clip-path" transform="translate(-5 3)">
         <rect width="40" height="40" fill="none"/>
       </clipPath>
-      <linearGradient id="Degradado_sin_nombre"
-                      data-name="Degradado sin nombre"
-                      x1="19.999"
-                      y1="59.39"
-                      x2="19.998"
-                      y2="-0.11"
-                      gradientTransform="matrix(1, 0, 0, -1, 0, 39.89)"
-                      gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0" stop-color="#adaded"/>
-        <stop offset="1" stop-color="#7878c9"/>
-      </linearGradient>
       <mask id="mask"
-            x="0"
+            x="3"
             y="0"
-            width="40.797"
-            height="44"
+            width="24.461"
+            height="22.824"
             maskUnits="userSpaceOnUse"
       >
-        <g transform="translate(0.4 2)">
-          <g id="path-3-inside-1">
-            <path d="M35.907,3.12A40.264,40.264,0,0,0,20,0,40.273,40.273,0,0,0,4.088,3.12,4.123,4.123,0,0,0,1.6,6.887V19.059A21.409,21.409,0,0,0,15.786,38.9l1.788.667a7.025,7.025,0,0,0,4.851,0l1.784-.667A21.4,21.4,0,0,0,38.4,19.059V6.887a4.12,4.12,0,0,0-2.49-3.767Z" fill="#fff"/>
+        <g transform="translate(-5 3)">
+          <g id="path-1-inside-1">
+            <path d="M11,16.824V9.231a9.231,9.231,0,1,1,18.462,0v7.593" fill="#fff"/>
           </g>
         </g>
       </mask>
       <mask id="mask-2"
-            x="14.7"
-            y="9.575"
-            width="11.619"
-            height="10.842"
+            x="0"
+            y="19"
+            width="30"
+            height="24"
             maskUnits="userSpaceOnUse"
       >
-        <g transform="translate(0.4 2)">
-          <g id="path-4-inside-2">
-            <path d="M15.725,16.991V13.385a4.385,4.385,0,1,1,8.769,0v3.606" fill="#fff"/>
-          </g>
-        </g>
-      </mask>
-      <mask id="mask-3"
-            x="13.275"
-            y="18.6"
-            width="14.25"
-            height="11.4"
-            maskUnits="userSpaceOnUse"
-      >
-        <g transform="translate(0.4 2)">
+        <g transform="translate(-5 3)">
           <g id="mask0">
-            <rect x="12.875"
-                  y="16.6"
-                  width="14.25"
-                  height="11.4"
-                  rx="1.9"
+            <rect x="5"
+                  y="16"
+                  width="30"
+                  height="24"
+                  rx="4"
                   fill="#fac34b"
             />
           </g>
         </g>
       </mask>
-      <linearGradient id="Degradado_sin_nombre_2"
-                      data-name="Degradado sin nombre 2"
-                      x1="26.938"
-                      y1="17.499"
-                      x2="9.838"
-                      y2="9.186"
+      <linearGradient id="Degradado_sin_nombre"
+                      data-name="Degradado sin nombre"
+                      x1="34.607"
+                      y1="11.699"
+                      x2="-1.393"
+                      y2="-5.801"
                       gradientTransform="matrix(1, 0, 0, -1, 0, 39.89)"
                       gradientUnits="userSpaceOnUse"
       >
         <stop offset="0" stop-color="#ffdc84"/>
         <stop offset="1" stop-color="#fbd677" stop-opacity="0"/>
       </linearGradient>
-      <mask id="mask-4"
-            x="17.55"
-            y="20.5"
-            width="5.7"
-            height="5.7"
-            maskUnits="userSpaceOnUse"
-      >
-        <g transform="translate(0.4 2)">
-          <g id="path-9-inside-3">
-            <path d="M20,19.45a1.9,1.9,0,1,1-1.9,1.9A1.9,1.9,0,0,1,20,19.45Z" fill="#fff"/>
-          </g>
-        </g>
-      </mask>
-      <mask id="mask-5"
-            x="18.975"
-            y="23.825"
-            width="2.85"
-            height="4.275"
-            maskUnits="userSpaceOnUse"
-      >
-        <g transform="translate(0.4 2)">
-          <g id="path-10-inside-4">
-            <path d="M19.05,22.3h1.9v2.375a.95.95,0,0,1-1.9,0Z" fill="#fff"/>
-          </g>
-        </g>
-      </mask>
     </defs>
     <g clip-path="url(#clip-path)">
       <g>
-        <path d="M35.907,3.12A40.264,40.264,0,0,0,20,0,40.273,40.273,0,0,0,4.088,3.12,4.123,4.123,0,0,0,1.6,6.887V19.059A21.409,21.409,0,0,0,15.786,38.9l1.788.667a7.025,7.025,0,0,0,4.851,0l1.784-.667A21.4,21.4,0,0,0,38.4,19.059V6.887a4.12,4.12,0,0,0-2.49-3.767Z" transform="translate(0.4 2)" fill="url(#Degradado_sin_nombre)"/>
-        <path d="M4.088,3.12A40.273,40.273,0,0,1,20,0l0,40a7.025,7.025,0,0,1-2.426-.432L15.786,38.9A21.409,21.409,0,0,1,1.6,19.059V6.887A4.125,4.125,0,0,1,4.088,3.12Z" transform="translate(0.4 2)" fill="#7878c9" opacity="0.5" style="isolation: isolate"/>
         <g mask="url(#mask)">
-          <path d="M35.907,3.12A40.264,40.264,0,0,0,20,0,40.273,40.273,0,0,0,4.088,3.12,4.123,4.123,0,0,0,1.6,6.887V19.059A21.409,21.409,0,0,0,15.786,38.9l1.788.667a7.025,7.025,0,0,0,4.851,0l1.784-.667A21.4,21.4,0,0,0,38.4,19.059V6.887a4.12,4.12,0,0,0-2.49-3.767Z" transform="translate(0.4 2)" fill="none" stroke="#ebecf0" stroke-width="4"/>
+          <path d="M8,16.824a3,3,0,0,0,6,0Zm18.462,0a3,3,0,1,0,6,0ZM14,16.824V9.231H8v7.593Zm0-7.593A6.232,6.232,0,0,1,20.231,3V-3A12.232,12.232,0,0,0,8,9.231ZM20.231,3a6.232,6.232,0,0,1,6.231,6.231h6A12.231,12.231,0,0,0,20.231-3Zm6.231,6.231v7.593h6V9.231Z" transform="translate(-5 3)" fill="#dfe1e6"/>
         </g>
+        <rect y="19" width="30" height="24" rx="4" fill="#fac34b"/>
         <g mask="url(#mask-2)">
-          <path d="M14.3,16.991a1.425,1.425,0,0,0,2.85,0Zm8.769,0a1.425,1.425,0,0,0,2.85,0Zm-5.919,0V13.385H14.3v3.606Zm0-3.606a2.96,2.96,0,0,1,2.96-2.96V7.575a5.81,5.81,0,0,0-5.81,5.81Zm2.96-2.96a2.959,2.959,0,0,1,2.959,2.96h2.85a5.809,5.809,0,0,0-5.809-5.81Zm2.959,2.96v3.606h2.85V13.385Z" transform="translate(0.4 2)" fill="#dfe1e6"/>
+          <path d="M35,40V16L5,40Z" transform="translate(-5 3)" opacity="0.5" fill="url(#Degradado_sin_nombre)" style="isolation: isolate"/>
         </g>
-        <rect x="13.275"
-              y="18.6"
-              width="14.25"
-              height="11.4"
-              rx="1.9"
-              fill="#fac34b"
+        <path d="M20,23a3,3,0,1,1-3,3A3,3,0,0,1,20,23Z"
+              transform="translate(-5 3)"
+              fill="#c87c1b"
+              stroke="#c87c1b"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
         />
-        <g mask="url(#mask-3)">
-          <path d="M27.125,28V16.6L12.875,28Z" transform="translate(0.4 2)" opacity="0.5" fill="url(#Degradado_sin_nombre_2)" style="isolation: isolate"/>
-        </g>
-        <g mask="url(#mask-4)">
-          <path d="M20,19.45a1.9,1.9,0,1,1-1.9,1.9A1.9,1.9,0,0,1,20,19.45Z"
-                transform="translate(0.4 2)"
-                fill="#c87c1b"
-                stroke="#c87c1b"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.9"
-          />
-        </g>
-        <g mask="url(#mask-5)">
-          <path d="M19.05,22.3h1.9v2.375a.95.95,0,0,1-1.9,0Z" transform="translate(0.4 2)" fill="#c87c1b" stroke="#c87c1b" stroke-width="0.95"/>
-        </g>
+        <path d="M18.5,28.5h3V33a1.5,1.5,0,0,1-3,0Z" transform="translate(-5 3)" fill="#c87c1b" stroke="#c87c1b"/>
       </g>
     </g>
   </svg>


### PR DESCRIPTION
## Description

  * Bumped the `PATCH` version in `package.json`.
  * Fixed `ColorLockIcon` with the right SVG

## Testing
  
  * `npm run lint`: **PASS**
  * `npm run prepare`: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
