### PR TITLE
Fix Rollup SVG config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.8.1",
+	"version": "4.8.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.8.1",
+	"version": "4.8.2",
 	"description": "Lana B2C Microapp UI Assets, icons and images for general use.",
 	"repository": {
 		"type": "git",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -35,7 +35,7 @@ const config = {
       plugins: [autoprefixer()],
       modules: true,
     }),
-    svg(),
+    svg({ svgoConfig: { plugins: [{ cleanupIDs: false }] } }),
     vue({ css: false }),
     babel({
       ...babelConfig,

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -36,7 +36,7 @@ const config = {
       plugins: [autoprefixer()],
       modules: true,
     }),
-    svg(),
+    svg({ svgoConfig: { plugins: [{ cleanupIDs: false }] } }),
     vue({ css: false }),
     babel({
       ...babelConfig,


### PR DESCRIPTION
## Description

  * Updated the rollup config for our SVG plugin to stop minifying id attributes.
  * Bumped the `PATCH` version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run prepare`: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
