### PR TITLE
Disable all other Rollup SVG transformation plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.8.2",
+	"version": "4.8.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lana/b2c-mapp-ui-assets",
-	"version": "4.8.2",
+	"version": "4.8.3",
 	"description": "Lana B2C Microapp UI Assets, icons and images for general use.",
 	"repository": {
 		"type": "git",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -7,6 +7,8 @@ import globals from 'rollup-plugin-node-globals';
 import postcss from 'rollup-plugin-postcss';
 import autoprefixer from 'autoprefixer';
 
+import { svgOptions } from './rollupHelper';
+
 const babelConfig = require('./babel.config');
 
 const config = {
@@ -35,7 +37,7 @@ const config = {
       plugins: [autoprefixer()],
       modules: true,
     }),
-    svg({ svgoConfig: { plugins: [{ cleanupIDs: false }] } }),
+    svg(svgOptions),
     vue({ css: false }),
     babel({
       ...babelConfig,

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -8,6 +8,8 @@ import globals from 'rollup-plugin-node-globals';
 import postcss from 'rollup-plugin-postcss';
 import autoprefixer from 'autoprefixer';
 
+import { svgOptions } from './rollupHelper';
+
 const babelConfig = require('./babel.config');
 
 const config = {
@@ -36,7 +38,7 @@ const config = {
       plugins: [autoprefixer()],
       modules: true,
     }),
-    svg({ svgoConfig: { plugins: [{ cleanupIDs: false }] } }),
+    svg(svgOptions),
     vue({ css: false }),
     babel({
       ...babelConfig,

--- a/rollupHelper.js
+++ b/rollupHelper.js
@@ -1,0 +1,43 @@
+const svgOptions = { // NOTE: We have to disable most of the SVGO plugins (see: https://github.com/svg/svgo) because they cause rendering problems with some of our icons
+  svgoConfig: {
+    plugins: [
+      { cleanupAttrs: false },
+      { inlineStyles: false },
+      { removeDoctype: false },
+      { removeXMLProcInst: false },
+      { removeComments: false },
+      { removeMetadata: false },
+      { removeTitle: false },
+      { removeDesc: false },
+      { removeUselessDefs: false },
+      { removeEditorsNSData: false },
+      { removeEmptyAttrs: false },
+      { removeHiddenElems: false },
+      { removeEmptyText: false },
+      { removeEmptyContainers: false },
+      { removeViewBox: false },
+      { cleanupEnableBackground: false },
+      { minifyStyles: false },
+      { convertStyleToAttrs: false },
+      { convertColors: false },
+      { convertPathData: false },
+      { convertTransform: false },
+      { removeUnknownsAndDefaults: false },
+      { removeNonInheritableGroupAttrs: false },
+      { removeUselessStrokeAndFill: false },
+      { removeUnusedNS: false },
+      { cleanupIDs: false },
+      { cleanupNumericValues: false },
+      { moveElemsAttrsToGroup: false },
+      { moveGroupAttrsToElems: false },
+      { collapseGroups: false },
+      { mergePaths: false },
+      { convertShapeToPath: false },
+      { convertEllipseToCircle: false },
+    ],
+  },
+};
+
+export {
+  svgOptions,
+};


### PR DESCRIPTION
## Description

  * Updated Rollup SVG plugin config to stop all SVG transformations in hopes of **finally** fixing the icon issues 🤞 
  * Bumped the `PATCH` version in `package.json`

## Testing
 
  * `npm run lint`: **PASS**
  * `npm run prepare`: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
