### PR TITLE
Brazil and Spain flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lana/b2c-mapp-ui-assets",
-  "version": "5.24.0",
+  "version": "5.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui-assets",
-      "version": "5.24.0",
+      "version": "5.25.0",
       "license": "ISC",
       "dependencies": {
         "vue": "^3.2.31"
@@ -3088,9 +3088,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -7071,9 +7071,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui-assets",
-  "version": "5.24.0",
+  "version": "5.25.0",
   "description": "Lana B2C Microapp UI Assets, icons and images for general use.",
   "repository": {
     "type": "git",

--- a/src/icons/brazil.svg
+++ b/src/icons/brazil.svg
@@ -1,0 +1,12 @@
+<svg class="icon" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#brazil-clip0_42554_289545)">
+<path d="M0 6.80005C0 5.69548 0.895431 4.80005 2 4.80005L30 4.80005C31.1046 4.80005 32 5.69548 32 6.80005V25.2001C32 26.3046 31.1046 27.2001 30 27.2001H2C0.895431 27.2001 0 26.3046 0 25.2001L0 6.80005Z" fill="#4ABE6B"/>
+<path d="M15.9996 6.40015L1.59961 16.0001L15.9996 25.6001L30.3996 16.0001L15.9996 6.40015Z" fill="#FAC34B"/>
+<circle cx="16.0004" cy="16.0001" r="5.6" fill="#004281"/>
+</g>
+<defs>
+<clipPath id="brazil-clip0_42554_289545">
+<rect width="32" height="32" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/icons/spain.svg
+++ b/src/icons/spain.svg
@@ -1,0 +1,5 @@
+<svg class="icon" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 6.80005C0 5.69548 0.895431 4.80005 2 4.80005H30C31.1046 4.80005 32 5.69548 32 6.80005V12H0V6.80005Z" fill="#EB4B68"/>
+<path d="M0 20H32V25.2C32 26.3046 31.1046 27.2 30 27.2H2C0.895431 27.2 0 26.3046 0 25.2V20Z" fill="#EB4B68"/>
+<path d="M0 12H32V20H0V12Z" fill="#FAC34B"/>
+</svg>

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import BlankCardImage from './icons/blankCard.svg?component';
 import BlueGemIcon from './icons/blueGem.svg?component';
 import BoltIcon from './icons/bolt.svg?component';
 import BoxIcon from './icons/box.svg?component';
+import BrazilIcon from './icons/brazil.svg?component';
 import BuildingIcon from './icons/building.svg?component';
 import BulbIcon from './icons/bulb.svg?component';
 import CabifyIcon from './icons/cabify.svg?component';
@@ -352,6 +353,7 @@ import SmallCircleIcon from './icons/smallCircle.svg?component';
 import SmileyIcon from './icons/smiley.svg?component';
 import SmsIcon from './icons/sms.svg?component';
 import SnowFlakeIcon from './icons/snowflake.svg?component';
+import SpainIcon from './icons/spain.svg?component';
 import SpeakerIcon from './icons/speaker.svg?component';
 import StarsIcon from './icons/stars.svg?component';
 import StarsMicroillustration from './icons/starsMicroillustration.svg?component';
@@ -462,6 +464,7 @@ export {
   BlueGemIcon,
   BoltIcon,
   BoxIcon,
+  BrazilIcon,
   BuildingIcon,
   BulbIcon,
   CabifyIcon,
@@ -785,6 +788,7 @@ export {
   SmileyIcon,
   SmsIcon,
   SnowFlakeIcon,
+  SpainIcon,
   SpeakerIcon,
   StarsIcon,
   StarsMicroillustration,


### PR DESCRIPTION
## Description
Add Brazil and Spain flags

## Screenshots/Captures

![Brasil](https://user-images.githubusercontent.com/1281392/159554925-b907bfb1-0ce2-4823-b7d0-d5cbc9c6244e.svg)
![Spain](https://user-images.githubusercontent.com/1281392/159554930-38b81350-eefc-4e90-8ec2-baf6e805f197.svg)

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
